### PR TITLE
Make partial examples runnable in REPL

### DIFF
--- a/content/en/about/libraries-addons.md
+++ b/content/en/about/libraries-addons.md
@@ -59,4 +59,4 @@ A collection of modules built to work wonderfully with Preact.
 - :tophat: [**preact-classless-component**](https://github.com/ld0rman/preact-classless-component): create preact components without the class keyword
 - :hammer: [**preact-hyperscript**](https://github.com/queckezz/preact-hyperscript): Hyperscript-like syntax for creating elements
 - :white_check_mark: [**shallow-compare**](https://github.com/tkh44/shallow-compare): simplified `shouldComponentUpdate` helper.
-- :signal_strength: [**preact-signal-store**](https://github.com/EthanStandel/preact-signal-store): Extension of `@preact/signals` for full state management
+- :signal_strength: [**@deepsignal/preact**](https://github.com/EthanStandel/deepsignal/tree/main/packages/preact): Extension of `@preact/signals` for full state management

--- a/content/en/blog/introducing-signals.md
+++ b/content/en/blog/introducing-signals.md
@@ -174,7 +174,7 @@ const count = signal(0);
 <p>Value: {count}</p>
  
 // … or even passing them as DOM properties:
-<input value={count} />
+<input value={count} onInput={...} />
 ```
 
 So yeah, we did that too. You can pass a signal directly into the JSX anywhere you'd normally use a string. The signal's value will be rendered as text, and it will automatically update itself when the signal changes. This also works for props.

--- a/content/en/blog/signal-boosting.md
+++ b/content/en/blog/signal-boosting.md
@@ -74,7 +74,7 @@ console.log(c.value); // Console: Hello World
 s2.value = "darkness my old friend";
 
 // s2 has changed, so the computation function runs again
-console.log(c.value); // Console: Hello darkness, my old friend
+console.log(c.value); // Console: Hello darkness my old friend
 ```
 
 As it happens, computed signals are themselves signals. A computed signal can depend on other computed signals.
@@ -146,7 +146,7 @@ const count = signal(1);
 const double = computed(() => count.value * 2);
 const quadruple = computed(() => double.value * 2);
 
-const disposer = effect(() => {
+const dispose = effect(() => {
   console.log("quadruple is now", quadruple.value);
 });                 // Console: quadruple value is now 4
 

--- a/content/en/blog/signal-boosting.md
+++ b/content/en/blog/signal-boosting.md
@@ -184,7 +184,7 @@ const dispose = effect(() => {
   console.log("quadruple is now", quadruple.value);
 });                 // Console: quadruple value is now 4
 
-disposer();
+dispose();
 count.value = 20;  // nothing gets printed to the console
 ```
 

--- a/content/en/blog/signal-boosting.md
+++ b/content/en/blog/signal-boosting.md
@@ -178,7 +178,7 @@ When you're done with an effect, call the _disposer_ that got returned when the 
 
 ```js
 // --repl
-import { signal, computed } from "@preact/signals";
+import { signal, computed, effect } from "@preact/signals";
 
 // --repl-before
 const count = signal(1);

--- a/content/en/blog/signal-boosting.md
+++ b/content/en/blog/signal-boosting.md
@@ -64,12 +64,36 @@ const c = computed(() => {
 The compute function given to `computed(...)` won't run immediately. That's because computed signals are evaluated _lazily_, i.e. when their values are read.
 
 ```js
+// --repl
+import { signal, computed } from "@preact/signals";
+
+const s1 = signal("Hello");
+const s2 = signal("World");
+
+const c = computed(() => {
+  return s1.value + " " + s2.value;
+});
+
+// --repl-before
 console.log(c.value); // Console: Hello World
 ```
 
 Computed values are also _cached_. Their compute functions can potentially be very expensive, so we want to rerun them only when it matters. A running compute function tracks which signal values are actually read during its run. If none of the values have changed, then we can skip recomputation. In the above example, we can just reuse the previously calculated `c.value` indefinitely as long as both `a.value` and `b.value` stay the same. Facilitating this _dependency tracking_ is the reason why we need to wrap the primitive values into signals in the first place.
 
 ```js
+// --repl
+import { signal, computed } from "@preact/signals";
+
+const s1 = signal("Hello");
+const s2 = signal("World");
+
+const c = computed(() => {
+  return s1.value + " " + s2.value;
+});
+
+console.log(c.value); // Console: Hello World
+
+// --repl-before
 // s1 and s2 haven't changed, no recomputation here
 console.log(c.value); // Console: Hello World
 
@@ -85,6 +109,7 @@ As it happens, computed signals are themselves signals. A computed signal can de
 // --repl
 import { signal, computed } from "@preact/signals";
 
+// --repl-before
 const count = signal(1);
 const double = computed(() => count.value * 2);
 const quadruple = computed(() => double.value * 2);
@@ -100,6 +125,7 @@ The set of dependencies doesn't have to stay static. The computed signal will on
 // --repl
 import { signal, computed } from "@preact/signals";
 
+// --repl-before
 const choice = signal(true);
 const funk = signal("Uptown");
 const purple = signal("Haze");
@@ -154,6 +180,7 @@ When you're done with an effect, call the _disposer_ that got returned when the 
 // --repl
 import { signal, computed } from "@preact/signals";
 
+// --repl-before
 const count = signal(1);
 const double = computed(() => count.value * 2);
 const quadruple = computed(() => double.value * 2);
@@ -202,6 +229,7 @@ Sets also have the property they're iterated in insertion order. Which is cool -
 // --repl
 import { signal, computed } from "@preact/signals";
 
+// --repl-before
 const s1 = signal(0);
 const s2 = signal(0);
 const s3 = signal(0);

--- a/content/en/blog/signal-boosting.md
+++ b/content/en/blog/signal-boosting.md
@@ -34,7 +34,7 @@ Signals represent arbitrary JavaScript values wrapped into a reactive shell. You
 
 ```js
 // --repl
-import { signal } from "@preact/signals";
+import { signal } from "@preact/signals-core";
 
 const s = signal(0);
 console.log(s.value); // Console: 0
@@ -51,7 +51,7 @@ _Computed signals_ derive new values from other signals using _compute functions
 
 ```js
 // --repl
-import { signal, computed } from "@preact/signals";
+import { signal, computed } from "@preact/signals-core";
 
 const s1 = signal("Hello");
 const s2 = signal("World");
@@ -65,7 +65,7 @@ The compute function given to `computed(...)` won't run immediately. That's beca
 
 ```js
 // --repl
-import { signal, computed } from "@preact/signals";
+import { signal, computed } from "@preact/signals-core";
 
 const s1 = signal("Hello");
 const s2 = signal("World");
@@ -73,7 +73,6 @@ const s2 = signal("World");
 const c = computed(() => {
   return s1.value + " " + s2.value;
 });
-
 // --repl-before
 console.log(c.value); // Console: Hello World
 ```
@@ -82,7 +81,7 @@ Computed values are also _cached_. Their compute functions can potentially be ve
 
 ```js
 // --repl
-import { signal, computed } from "@preact/signals";
+import { signal, computed } from "@preact/signals-core";
 
 const s1 = signal("Hello");
 const s2 = signal("World");
@@ -92,7 +91,6 @@ const c = computed(() => {
 });
 
 console.log(c.value); // Console: Hello World
-
 // --repl-before
 // s1 and s2 haven't changed, no recomputation here
 console.log(c.value); // Console: Hello World
@@ -107,8 +105,7 @@ As it happens, computed signals are themselves signals. A computed signal can de
 
 ```js
 // --repl
-import { signal, computed } from "@preact/signals";
-
+import { signal, computed } from "@preact/signals-core";
 // --repl-before
 const count = signal(1);
 const double = computed(() => count.value * 2);
@@ -123,8 +120,7 @@ The set of dependencies doesn't have to stay static. The computed signal will on
 
 ```js
 // --repl
-import { signal, computed } from "@preact/signals";
-
+import { signal, computed } from "@preact/signals-core";
 // --repl-before
 const choice = signal(true);
 const funk = signal("Uptown");
@@ -159,7 +155,7 @@ Like computed signals, effects are also created with a function (_effect functio
 
 ```js
 // --repl
-import { signal, computed, effect } from "@preact/signals";
+import { signal, computed, effect } from "@preact/signals-core";
 
 const count = signal(1);
 const double = computed(() => count.value * 2);
@@ -178,8 +174,7 @@ When you're done with an effect, call the _disposer_ that got returned when the 
 
 ```js
 // --repl
-import { signal, computed, effect } from "@preact/signals";
-
+import { signal, computed, effect } from "@preact/signals-core";
 // --repl-before
 const count = signal(1);
 const double = computed(() => count.value * 2);
@@ -227,8 +222,7 @@ Sets also have the property they're iterated in insertion order. Which is cool -
 
 ```js
 // --repl
-import { signal, computed } from "@preact/signals";
-
+import { signal, computed } from "@preact/signals-core";
 // --repl-before
 const s1 = signal(0);
 const s2 = signal(0);

--- a/content/en/guide/v10/differences-to-react.md
+++ b/content/en/guide/v10/differences-to-react.md
@@ -18,7 +18,7 @@ The reason Preact does not attempt to include every single feature of React is i
 
 ## Main differences
 
-The main difference between Preact and React is that Preact does not implement a synthetic event system for size and performance reasons. Preact uses the browser's standard `addEventListener` to register event handlers, which means event naming and behavior works the same in Preact as it does in plain JavaScript / DOM. See [GlobalEventHandlers] for a full list of DOM event handlers.
+The main difference between Preact and React is that Preact does not implement a synthetic event system for size and performance reasons. Preact uses the browser's standard `addEventListener` to register event handlers, which means event naming and behavior works the same in Preact as it does in plain JavaScript / DOM. See [MDN's Event Reference] for a full list of DOM event handlers.
 
 Standard browser events work very similarly to how events work in React, with a few small differences. In Preact:
 
@@ -218,4 +218,4 @@ A React-compatible `Children` API is available from `preact/compat` to make inte
 [Project Goals]: /about/project-goals
 [hyperscript]: https://github.com/dominictarr/hyperscript
 [preact/compat]: /guide/v10/switching-to-preact
-[GlobalEventHandlers]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers
+[MDN's Event Reference]: https://developer.mozilla.org/en-US/docs/Web/Events

--- a/content/ja/guide/v10/differences-to-react.md
+++ b/content/ja/guide/v10/differences-to-react.md
@@ -20,7 +20,7 @@ PreactがReactの機能をすべて含まない理由は**小さい**、**集中
 
 PreactとReactの主な違いはPreactには合成イベント(Synthetic Event)がないことです。
 Preactはイベント処理に内部でブラウザネイティブの`addEventListener`を使用しています。
-DOMイベントハンドラの完全なリストは[GlobalEventHandlers]を見てください。
+DOMイベントハンドラの完全なリストは[MDN's Event Reference]を見てください。
 
 ブラウザのイベントシステムは必要なすべての機能を満たしているので、Preactにとって合成イベントは意味がありません。
 合成イベントのようなカスタムイベントを完全に実装するとメンテナンスのオーバーヘッドが増加しAPIが複雑になってしまいます。
@@ -193,4 +193,4 @@ function App(props) {
 [Projectの目的]: /about/project-goals
 [hyperscript]: https://github.com/dominictarr/hyperscript
 [preact/compat]: /guide/v10/switching-to-preact
-[GlobalEventHandlers]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers
+[MDN's Event Reference]: https://developer.mozilla.org/en-US/docs/Web/Events

--- a/content/ja/guide/v10/differences-to-react.md
+++ b/content/ja/guide/v10/differences-to-react.md
@@ -193,4 +193,4 @@ function App(props) {
 [Projectの目的]: /about/project-goals
 [hyperscript]: https://github.com/dominictarr/hyperscript
 [preact/compat]: /guide/v10/switching-to-preact
-[MDN's Event Reference]: https://developer.mozilla.org/en-US/docs/Web/Events
+[MDN's Event Reference]: https://developer.mozilla.org/ja/docs/Web/Events

--- a/content/kr/guide/v10/differences-to-react.md
+++ b/content/kr/guide/v10/differences-to-react.md
@@ -18,7 +18,7 @@ Preact가 React의 모든 기능을 하나하나 포함하지 않으려는 이�
 
 ## 주요 차이점
 
-Preact 앱과 React 앱을 비교할 때 주요 차이점은 Preact에서는 자체 이벤트 시스템을 제공하지 않는다는 점입니다. Preact는 내부에서 모든 이벤트를 핸들링할 때 브라우저에서 제공하는 `addEventListner`를 사용합니다. 모든 DOM 이벤트 핸들러에 대한 리스트를 보려면 [GlobalEventHandlers]를 보세요.
+Preact 앱과 React 앱을 비교할 때 주요 차이점은 Preact에서는 자체 이벤트 시스템을 제공하지 않는다는 점입니다. Preact는 내부에서 모든 이벤트를 핸들링할 때 브라우저에서 제공하는 `addEventListner`를 사용합니다. 모든 DOM 이벤트 핸들러에 대한 리스트를 보려면 [MDN's Event Reference]를 보세요.
 
 브라우저의 이벤트 시스템에서 우리가 필요로 하는 모든 기능을 지원합니다. 자체적인 커스텀 이벤트를 구현하는 건 유지보수 비용 증대와 API 영역의 확장을 의미합니다.
 
@@ -221,4 +221,4 @@ React와 호환되는 `Children` API는 `preact/compat`에서 제공되며 기�
 [Project Goals]: /about/project-goals
 [hyperscript]: https://github.com/dominictarr/hyperscript
 [preact/compat]: /guide/v10/switching-to-preact
-[GlobalEventHandlers]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers
+[MDN's Event Reference]: https://developer.mozilla.org/ko/docs/Web/Events

--- a/content/pt-br/guide/v10/differences-to-react.md
+++ b/content/pt-br/guide/v10/differences-to-react.md
@@ -18,7 +18,7 @@ Preact não tenta incluir cada pequeno recurso do React em razão manter-se **pe
 
 ## Principais diferenças
 
-A principal diferença ao comparar os aplicativos Preact e React é que não enviamos nosso próprio sistema de evento sintético. O Preact usa o `addEventlistener` nativo do navegador para manipulação de eventos internamente. Consulte [Manipuladores de Evento Globais] para obter uma lista completa dos manipuladores de eventos DOM.
+A principal diferença ao comparar os aplicativos Preact e React é que não enviamos nosso próprio sistema de evento sintético. O Preact usa o `addEventlistener` nativo do navegador para manipulação de eventos internamente. Consulte [MDN's Event Reference] para obter uma lista completa dos manipuladores de eventos DOM.
 
 Para nós, não faz sentido, pois o sistema de eventos do navegador suporta todos os recursos que precisamos. Uma implementação completa de eventos personalizados significaria mais sobrecarga de manutenção e uma maior área de superfície da API para nós.
 
@@ -152,4 +152,4 @@ function App(props) {
 [Objetivos do projeto]: /about/project-goals
 [hyperscript]: https://github.com/dominictarr/hyperscript
 [preact/compat]: /guide/v10/switching-to-preact
-[Manipuladores de Evento Globais]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers
+[MDN's Event Reference]: https://developer.mozilla.org/pt-BR/docs/Web/Events

--- a/src/components/controllers/repl/repl.setup.js
+++ b/src/components/controllers/repl/repl.setup.js
@@ -6,6 +6,7 @@ import * as htm from 'htm';
 import * as htmPreact from 'htm/preact';
 import * as preactCustomElement from 'preact-custom-element';
 import * as preactSignals from '@preact/signals';
+import * as preactSignalsCore from '@preact/signals-core';
 
 let modules = {};
 let moduleCache = {
@@ -17,6 +18,7 @@ let moduleCache = {
 	'react-dom': compat,
 	htm,
 	'@preact/signals': preactSignals,
+	'@preact/signals-core': preactSignalsCore,
 	'htm/preact': htmPreact,
 	'preact-custom-element': preactCustomElement
 };


### PR DESCRIPTION
This pull request is continuation to https://github.com/preactjs/preact-www/pull/923, and makes the following modifications:
 * Make also the partial examples runnable in REPL. Thanks to the handy `// --repl-before` feature the partial examples still look similar in the blog post 🎉
 * Update the internal config to allow imports from `@preact/signals-core`, and modify the imports accordingly.
 * Merge the changes from the current main branch to try to mitigate trouble from potentially overlapping changes. Unfortunately this makes this PR's diff more noisy, but it _should_ be ok if the `patch-1` branch gets merged to the preact/preact-www repo.

If this PR gets merged then I _think_ https://github.com/preactjs/preact-www/pull/923 gets updated automatically if we just reopen it.